### PR TITLE
DERP-352 - Change from a custom module to contrib module

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "gla/accelerator-person-lgov-package",
-    "type": "drupal-custom-module",
+    "type": "drupal-module",
     "license": "OGL-3.0",
     "description": "Site specific person package used by the london.gov.uk instance of the GLA drupal accelerator"
 }

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "gla/accelerator-person-lgov-package",
-    "type": "drupal-module",
+    "type": "gla-estate-module",
     "license": "OGL-3.0",
     "description": "Site specific person package used by the london.gov.uk instance of the GLA drupal accelerator"
 }


### PR DESCRIPTION
Estate level features such as this needs to be treated more like a contrib module where you cannot alter the code at site level.

My recommendation is to treat packages like this as "drupal-module" instead of "drupal-custom-module"
https://github.com/GreaterLondonAuthority/accelerator-core-alpha/blob/main/composer.json#L119

If you look at the code you can see "drupal-custom-module" places the code into the custom directory.
Normally in Drupal practice anything in the custom folder is editable, this is not something we want from estate level modules.